### PR TITLE
Clarify internship project details and target audience

### DIFF
--- a/_internships/available.md
+++ b/_internships/available.md
@@ -5,7 +5,7 @@ layout: internships-list
 permalink: /internships/
 ---
 
-This page lists the internship projects currently available in the Center for Cybersecurity of [Fondazione Bruno Kessler](https://www.fbk.eu) (FBK). Please note that these are curricular internship projects intended for university students and are not employment contracts (hence, they are not paid). Please refer to [jobs.fbk.eu/](https://jobs.fbk.eu/) for job offers and open positions.
+This page lists the internship projects currently available in the Center for Cybersecurity of [Fondazione Bruno Kessler](https://www.fbk.eu) (FBK). Please note that these are <b>curricular internship projects</b> (which does not include financial compensation) <b>intended specifically for bachelor's and master's university students</b>, and not employment contracts. Please refer to [jobs.fbk.eu/](https://jobs.fbk.eu/) for job offers and open positions.
 
 <blockquote>
     <h1 class="no-toc">Procedure</h1>


### PR DESCRIPTION
Updated the description of internship projects to clarify that they are curricular and intended for bachelor's and master's university students, and highlighted that they do not include financial compensation.